### PR TITLE
[ez] Update /ping endpoint to return object rather than direct string

### DIFF
--- a/tiny-client/src/App.js
+++ b/tiny-client/src/App.js
@@ -7,7 +7,7 @@ function App() {
 
   const makePingAPIRequest = () => {
     fetch('http://localhost:8080/api/ping')
-      .then(res => res.text())
+      .then(res => res.json())
       .then(resText => console.log(resText));
   };
 

--- a/tiny-server/src/main.ts
+++ b/tiny-server/src/main.ts
@@ -33,7 +33,9 @@ MongoClient.connect(mongoDBAddress).then(mongoClient => {
 
     // ***API: PING***
     app.get('/api/ping', (_, res) => {
-        res.send('pong');
+        res.send({
+            message: 'data'
+        });
     });
 }).catch(err => {
     console.error('Unable to connect to MongoDB.', err);

--- a/tiny-server/src/main.ts
+++ b/tiny-server/src/main.ts
@@ -34,7 +34,7 @@ MongoClient.connect(mongoDBAddress).then(mongoClient => {
     // ***API: PING***
     app.get('/api/ping', (_, res) => {
         res.send({
-            message: 'data'
+            message: 'pong'
         });
     });
 }).catch(err => {


### PR DESCRIPTION
## Context
We should keep our responses as non-primitives. This PR involves updating our '/api/ping' endpoint to adhere to this principle.

## Changes
Change endpoint (implicit) response type from `string` to `{ message: string; }`.

## Demo
<img width="437" alt="Screenshot 2023-08-30 at 2 33 24 PM" src="https://github.com/ChristianArredondo/tiny-web-app/assets/24460948/d2b1efdc-3213-41ee-8238-7b350a3630be">
